### PR TITLE
feat: replace placeholder.png with gradient placeholder in RaceCard

### DIFF
--- a/race-reports/src/RaceCard.js
+++ b/race-reports/src/RaceCard.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import AspectRatio from '@mui/joy/AspectRatio';
+import Box from '@mui/joy/Box';
 import Card from '@mui/joy/Card';
 import CardContent from '@mui/joy/CardContent';
 import CardOverflow from '@mui/joy/CardOverflow';
@@ -45,12 +46,33 @@ export default function RaceCard({
       <CardOverflow sx={{ position: 'relative' }}>
         <AspectRatio ratio="16/9" sx={{ transition: 'transform 0.25s', '&:hover': { transform: 'scale(1.02)' } }}>
           <a href={googlePhotosLink || undefined} target="_blank" rel="noreferrer">
-            <img
-              src={coverPhoto}
-              loading="lazy"
-              alt={nameEn}
-              style={{ width: '100%', height: '100%', cursor: googlePhotosLink ? 'pointer' : 'default' }}
-            />
+            {coverPhoto ? (
+              <img
+                src={coverPhoto}
+                loading="lazy"
+                alt={nameEn}
+                style={{ width: '100%', height: '100%', cursor: googlePhotosLink ? 'pointer' : 'default' }}
+              />
+            ) : (
+              <Box
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  background: 'linear-gradient(160deg, #5b8db8 0%, #3d6b52 100%)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 0.5,
+                  cursor: googlePhotosLink ? 'pointer' : 'default',
+                }}
+              >
+                <span style={{ fontSize: '2rem', opacity: 0.6 }}>⛰</span>
+                <Typography level="body-xs" sx={{ color: 'rgba(255,255,255,0.6)', letterSpacing: '0.05em' }}>
+                  No Photo
+                </Typography>
+              </Box>
+            )}
           </a>
         </AspectRatio>
         <Chip

--- a/race-reports/src/assets/races.json
+++ b/race-reports/src/assets/races.json
@@ -194,7 +194,7 @@
     "ascent": 0,
     "result": "off-course 28km",
     "status": "DNF",
-    "coverPhoto": "/race-reports/placeholder.png",
+    "coverPhoto": null,
     "googlePhotosLink": "https://photos.app.goo.gl/sfPPiQjTP8pPBBwK6"
   },
   {
@@ -339,7 +339,7 @@
     "ascent": 11000,
     "result": "TBD",
     "status": "Upcoming",
-    "coverPhoto": "/race-reports/placeholder.png",
+    "coverPhoto": null,
     "googlePhotosLink": "",
     "itraPoints": 6,
     "itraLink": "https://itra.run/Races/RaceDetails/Tokyo.Grand.Trail.100mile/2026/100353"


### PR DESCRIPTION
Races without a cover photo now display a sky-to-forest gradient with
a mountain icon and "No Photo" label instead of the generic image icon.
coverPhoto is set to null in races.json for placeholder entries, and
RaceCard.js renders the styled fallback when coverPhoto is falsy.

https://claude.ai/code/session_01GWfhH4zAn7JBmuKLoL1fvi