### PR TITLE
Move filter toggles to left side of map for mobile compatibility

### DIFF
--- a/race-reports/src/JapanMap.js
+++ b/race-reports/src/JapanMap.js
@@ -194,11 +194,12 @@ export default function JapanMap({ selected, onSelect, filters, showMarathons, s
           ))}
         </div>
 
-        {/* Filter toggles overlay — sits in the left-side whitespace (ocean west of Japan) */}
+        {/* Filter toggles overlay — right whitespace on desktop, left whitespace on mobile */}
         <div style={{
           position: 'absolute',
-          top: '28%',
-          left: '3%',
+          ...(SUPPORTS_HOVER
+            ? { bottom: '55%', right: '3%' }
+            : { top: '28%',   left:  '3%' }),
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'flex-start',

--- a/race-reports/src/JapanMap.js
+++ b/race-reports/src/JapanMap.js
@@ -194,11 +194,11 @@ export default function JapanMap({ selected, onSelect, filters, showMarathons, s
           ))}
         </div>
 
-        {/* Filter toggles overlay — sits above stats in the right-side whitespace */}
+        {/* Filter toggles overlay — sits in the left-side whitespace (ocean west of Japan) */}
         <div style={{
           position: 'absolute',
-          bottom: '55%',
-          right: '3%',
+          top: '28%',
+          left: '3%',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'flex-start',


### PR DESCRIPTION
The toggles were positioned in the right-side whitespace, which
overlapped the map content on narrow mobile screens. Moving them
to the left-side ocean whitespace (Sea of Japan area, top ~28%)
keeps them clear of Japan's landmass on both mobile and desktop.

https://claude.ai/code/session_018s3zUBNn68nCxrV5yRTQmR