### PR TITLE
Fix Okinawa hover popup by adding mouse handlers to inset container div

### DIFF
--- a/race-reports/src/JapanMap.js
+++ b/race-reports/src/JapanMap.js
@@ -229,6 +229,9 @@ export default function JapanMap({ selected, onSelect, filters, showMarathons, s
             if (!okinawaIsRaced) return;
             onSelect(selected === 'Okinawa' ? null : 'Okinawa');
           }}
+          onMouseEnter={SUPPORTS_HOVER ? (evt) => handleHover('Okinawa', evt.clientX, evt.clientY) : undefined}
+          onMouseMove={SUPPORTS_HOVER  ? (evt) => handleMove(evt.clientX, evt.clientY) : undefined}
+          onMouseLeave={SUPPORTS_HOVER ? handleHoverEnd : undefined}
           style={{
             position: 'absolute',
             bottom: '3%',


### PR DESCRIPTION
The SVG inside the Okinawa inset had pointerEvents: 'none' to make the
whole box the tap target on mobile. This also blocked desktop hover events.
Fix by attaching onMouseEnter/onMouseMove/onMouseLeave directly on the
container div (guarded by SUPPORTS_HOVER), so the tooltip fires on desktop
without affecting the mobile tap behaviour.

https://claude.ai/code/session_019HtJViY6bT5CjfJJzRYFC5